### PR TITLE
Update for instance name format change in 5.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,4 +9,4 @@ name = "pypi"
 troposphere = {extras = ["policy"]}
 
 [requires]
-python_version = "2.7"
+python_version = "3.8"

--- a/euca-me.py
+++ b/euca-me.py
@@ -71,6 +71,21 @@ class PowerDnsQuery(object):
             self.has_result = True
 
         elif (qtype == 'A' or qtype == 'ANY') and re.match(
+                '^ec2-(\d{1,3})-(\d{1,3})-(\d{1,3})-(\d{1,3})\.compute\.'
+                '[a-z0-9-]{0,32}?\d{1,3}-\d{1,3}-\d{1,3}-\d{1,3}\.euca\.me$',
+                qname_lower):
+            # instances, ...
+            match = re.match(
+                '^ec2-(\d{1,3})-(\d{1,3})-(\d{1,3})-(\d{1,3})\.compute\.'
+                '[a-z0-9-]{0,32}?\d{1,3}-\d{1,3}-\d{1,3}-\d{1,3}\.euca\.me$',
+                qname_lower)
+            self.results.append(
+                'DATA\t%s\t%s\tA\t%d\t-1\t%s'
+                % (qname, qclass, PowerDnsQuery.ttl,
+                   '%s.%s.%s.%s' % match.groups()))
+            self.has_result = True
+
+        elif (qtype == 'A' or qtype == 'ANY') and re.match(
                 '^euca-(\d{1,3})-(\d{1,3})-(\d{1,3})-(\d{1,3})\.eucalyptus\.'
                 '[a-z0-9-]{0,32}?\d{1,3}-\d{1,3}-\d{1,3}-\d{1,3}\.euca\.me$',
                 qname_lower):

--- a/template.py
+++ b/template.py
@@ -7,8 +7,8 @@ import troposphere.iam as iam
 
 template = Template()
 
-template.add_version("2010-09-09")
-template.add_description("euca.me dns and http services")
+template.set_version("2010-09-09")
+template.set_description("euca.me dns and http services")
 
 availability_zone_1 = template.add_parameter(Parameter(
     "AvailabilityZone1",


### PR DESCRIPTION
Update to support default instance name format in eucalyptus 5:

```
ec2-192-168-169-140.compute.cloud-10-88-0-8.euca.me
```

update to use current python for building cloudformation template.